### PR TITLE
Changing comment in sketch.js (`without-p5` branch)

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -1,3 +1,3 @@
 // Your code will go here
-// open up your console - if everything loaded properly you should see 0.3.0
+// open up your console - if everything loaded is properly, you should see 0.4.3
 console.log('ml5 version:', ml5.version);


### PR DESCRIPTION
In the index.html, the version of ml5.js used is v0.4.3 but line 2 in sketch.js shows the expected output to be v0.3.0